### PR TITLE
refactor: centralize evaluator keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ npm run reset
 npm run
 ```
 
+## Keyword Configuration
+
+The rule-based evaluator checks declarations against keyword lists for
+out-of-bounds claims and incoherent statements. These lists live in
+`src/rules/evaluatorKeywords.ts`. To handle new scenarios, add keywords
+to `OOB_KEYWORDS` or `NONSENSE_KEYWORDS`, then restart the server or
+rebuild the project.
+
 ## API Reference
 
 ### Create New Run

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1,13 +1,14 @@
 import OpenAI from 'openai'
-import { 
-  StatePacket, 
-  EvaluatorOutput, 
-  EvaluatorOutputSchema, 
+import {
+  StatePacket,
+  EvaluatorOutput,
+  EvaluatorOutputSchema,
   RngEvent,
   Direction,
   DirStrength,
   Caps
 } from './contracts'
+import { OOB_KEYWORDS, NONSENSE_KEYWORDS } from './rules/evaluatorKeywords'
 
 export class Evaluator {
   private openai: OpenAI | null = null
@@ -188,15 +189,13 @@ Respond ONLY with JSON conforming to the schema. No prose.`
     caps: Caps
   ): Promise<EvaluatorOutput> {
     const lowerDecl = declaration.toLowerCase()
-    
+
     // Check for out-of-bounds content
-    const oobKeywords = ['million', 'billion', 'dollar', 'funding', 'investment', 'acquisition', 'merger', 'recession', 'crisis']
-    const isOob = oobKeywords.some(keyword => lowerDecl.includes(keyword))
-    
+    const isOob = OOB_KEYWORDS.some(keyword => lowerDecl.includes(keyword))
+
     // Check for nonsense/incoherent content
-    const nonsenseKeywords = ['blah', 'random', 'nonsense', 'gibberish', 'test', 'placeholder']
-    const isNonsense = nonsenseKeywords.some(keyword => lowerDecl.includes(keyword)) || 
-                      declaration.length < 10 || 
+    const isNonsense = NONSENSE_KEYWORDS.some(keyword => lowerDecl.includes(keyword)) ||
+                      declaration.length < 10 ||
                       /^[^a-zA-Z]*$/.test(declaration)
     
     // Generate CEO signals based on content and state

--- a/src/rules/evaluatorKeywords.ts
+++ b/src/rules/evaluatorKeywords.ts
@@ -1,0 +1,26 @@
+// Keyword lists for rule-based evaluation
+//
+// Add new keywords to these arrays to handle additional out-of-bounds
+// scenarios or to catch incoherent declarations. This central module
+// allows the evaluator to be extended without modifying core logic.
+
+export const OOB_KEYWORDS = [
+  'million',
+  'billion',
+  'dollar',
+  'funding',
+  'investment',
+  'acquisition',
+  'merger',
+  'recession',
+  'crisis'
+]
+
+export const NONSENSE_KEYWORDS = [
+  'blah',
+  'random',
+  'nonsense',
+  'gibberish',
+  'test',
+  'placeholder'
+]


### PR DESCRIPTION
## Summary
- centralize out-of-bounds and nonsense keywords in `evaluatorKeywords.ts`
- consume keyword lists in rule-based evaluator
- document how to extend keyword lists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0e9de75a88333b70c04f393bc633a